### PR TITLE
Zeltlager updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ist [hier](https://github.com/kjg-dortmund-wickede/kjg-dortmund-wickede.github.i
 
  - - - -
  zu 1.:
-selbsterklärend! 
+selbsterklärend!
  - - - -
  zu 2.:
  - in den Ordner `_posts` wechseln
@@ -75,6 +75,15 @@ description: The description of the project
 
 ---
 ```
+### Jekyll läuft nicht
+
+Evtl. bundler und gems neu installieren
+```txt
+rm -rf _site
+gem install bundler
+bundle install
+```
+Dann sollte das 'bundle exec jekyll serve' wieder wie gewohnt funktionieren.
 
 ## Demo
 [Hier](https://kjg-dortmund-wickede.github.io) findet sich das Jekyll Theme in Aktion.

--- a/_posts/2018-01-08-Zeltlager-2018.md
+++ b/_posts/2018-01-08-Zeltlager-2018.md
@@ -4,7 +4,7 @@ modal-id: 8
 date: 2018-01-08
 img: zl-werbung-2018.jpg
 alt: image-alt
-project-date: 
+project-date: ab 13. August 2018
 client: Start Bootstrap
 category: recent
 description: Jedes Jahr fahren wir in den Sommerferien ins Zeltlager. Wir haben zwei Wochen Spaß, verbringen unsere Zeit in der Natur und neben vielen verschiedenen Spielen erleben wir vor allem das Gefühl der Gemeinschaft. Wir freuen uns über jedes Kind, dass bei uns mitfährt! Weitere Informationen findet ihr im <a target="_blank" href="/dokumente/zl-flyer/zl-flyer_2018_print.pdf">Flyer</a>.

--- a/_posts/2018-03-08-Zeltlager-2018.md
+++ b/_posts/2018-03-08-Zeltlager-2018.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 modal-id: 8
-date: 2018-01-08
+date: 2018-03-08
 img: zl-werbung-2018.jpg
 alt: image-alt
 project-date: ab 13. August 2018


### PR DESCRIPTION
Werbung für das Zeltlager sollte vorne auf der Homepage unter Aktuell auftauchen