### PR TITLE
Update 2020-01-04-Christkindlmarkt 2019.md

### DIFF
--- a/_posts/2020-01-04-Christkindlmarkt 2019.md
+++ b/_posts/2020-01-04-Christkindlmarkt 2019.md
@@ -2,7 +2,7 @@
 layout: default
 modal-id: 37
 date: 2020-01-04
-img: Christkindlmarkt2019.jpg
+img: Christkindlemarkt2019.jpg
 alt: image-alt
 project-date: 2019-12-01
 client: Start Bootstrap


### PR DESCRIPTION
Namen des Bildes geändert (wird aktuell nicht angezeigt, da ein "e" vergessen ist.